### PR TITLE
Open dev server site preview automatically

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -35,6 +35,8 @@ tasks:
     command: yarn cypress
   - command: git branch
 ports:
+  - port: 3000
+    onOpen: open-browser
   - port: 5900
     onOpen: ignore
   - port: 6080


### PR DESCRIPTION
## Changes

- Open port `3000` in new browser window

## Context

This makes it so that Gitpod opens the dev server preview in a new browser window automatically.